### PR TITLE
Feat/client/menu modal

### DIFF
--- a/client/src/components/FoodCard.js
+++ b/client/src/components/FoodCard.js
@@ -35,7 +35,7 @@ function FoodCard({ name, price, description, imageUrl }) {
       borderRadius: "2px",
     },
   };
-  
+
   return (
     <div style={classes.cardContainer}>
       <img src={imageUrl} style={classes.image} alt="Food Item" />

--- a/client/src/hooks/useMenuModal.js
+++ b/client/src/hooks/useMenuModal.js
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { Modal } from "@mui/material";
+import FoodCard from "../components/FoodCard";
 
 const classes = {
   modalContainer: {
@@ -8,9 +9,16 @@ const classes = {
     left: "50%",
     transform: "translate(-50%,-50%)",
     height: "70vh",
-    width: "min(100%,var(--content-width))",
-    backgroundColor: "black",
-    color: "white",
+    backgroundColor: "rgba(69,69,69,0.69)",
+    width: "calc(min(100%,var(--content-width)) - 2rem)",
+    overflowY: "auto",
+    boxSizing: "border-box",
+    paddingInline: "1rem",
+  },
+  foodList: {
+    display: "flex",
+    flexDirection: "column",
+    gap: "0.5rem",
   },
 };
 
@@ -24,7 +32,17 @@ export default function useMenuModal() {
     return (
       <Modal open={open} onClose={closeModal}>
         <div style={classes.modalContainer}>
-          {foods.map((food) => food.name)}
+          <div style={classes.foodList}>
+            {foods.map((food, idx) => (
+              <FoodCard
+                key={idx}
+                name={food.name}
+                price={food.price}
+                description={food.description}
+                imageUrl={food.image_url}
+              />
+            ))}
+          </div>
         </div>
       </Modal>
     );

--- a/client/src/hooks/useMenuModal.js
+++ b/client/src/hooks/useMenuModal.js
@@ -16,19 +16,23 @@ const classes = {
 
 export default function useMenuModal() {
   const [open, setOpen] = useState(false);
+  const [foods, setFoods] = useState([]);
   const openModal = () => setOpen(true);
   const closeModal = () => setOpen(false);
 
   function MenuModal() {
     return (
       <Modal open={open} onClose={closeModal}>
-        <div style={classes.modalContainer}>hi</div>
+        <div style={classes.modalContainer}>
+          {foods.map((food) => food.name)}
+        </div>
       </Modal>
     );
   }
 
   return {
     openModal,
+    setFoods,
     MenuModal,
   };
 }

--- a/client/src/pages/Restaurant/FoodList/index.js
+++ b/client/src/pages/Restaurant/FoodList/index.js
@@ -1,4 +1,4 @@
-import FoodCard from "./FoodCard";
+import FoodCard from "../../../components/FoodCard";
 
 const classes = {
   foodList: {

--- a/client/src/pages/Search/GridView/RestaurantCard/index.js
+++ b/client/src/pages/Search/GridView/RestaurantCard/index.js
@@ -3,7 +3,7 @@ import ImageCard from "./ImageCard";
 import Details from "./Details";
 import ChevronRightIcon from "@mui/icons-material/ChevronRight";
 import FastfoodIcon from "@mui/icons-material/Fastfood";
-import { IconButton } from "@mui/material";
+import { Button, IconButton } from "@mui/material";
 import { useNavigate } from "react-router-dom";
 
 const classes = {
@@ -31,16 +31,20 @@ const classes = {
   },
   foodCount: {
     display: "flex",
-    flexDirection: "column",
     alignItems: "center",
-    width: "100%",
+    gap: "0.25rem",
+    minHeight: 0,
+    minWidth: 0,
+    padding: 0,
+    paddingInline: "0.5rem",
+    marginRight: "0.5rem",
   },
   title: {
     fontSize: "0.9rem",
   },
 };
 
-function RestaurantCard({ restaurant, foods }) {
+function RestaurantCard({ restaurant, foods, setModalFoods, openModal }) {
   const navigate = useNavigate();
   return (
     <div style={classes.cardContainer}>
@@ -58,12 +62,21 @@ function RestaurantCard({ restaurant, foods }) {
         />
       </div>
       <div style={classes.foodInfo}>
-        <div style={classes.foodCount}>
-          <div style={{ fontSize: "0.75rem" }}>{foods.length}</div>
+        <Button
+          style={classes.foodCount}
+          variant="outlined"
+          onClick={() => {
+            setModalFoods(foods);
+            openModal();
+          }}
+        >
+          <span style={{ fontSize: "0.75rem", fontWeight: 400 }}>
+            {foods.length}
+          </span>
           <FastfoodIcon
             style={{ color: "hsl(30,90%,50%)", fontSize: "0.75rem" }}
           />
-        </div>
+        </Button>
         <IconButton
           style={{ padding: 0 }}
           onClick={() => {

--- a/client/src/pages/Search/GridView/RestaurantCard/index.js
+++ b/client/src/pages/Search/GridView/RestaurantCard/index.js
@@ -1,10 +1,8 @@
 import React from "react";
 import ImageCard from "./ImageCard";
 import Details from "./Details";
-import ChevronRightIcon from "@mui/icons-material/ChevronRight";
 import FastfoodIcon from "@mui/icons-material/Fastfood";
-import { Button, IconButton } from "@mui/material";
-import { useNavigate } from "react-router-dom";
+import { Button } from "@mui/material";
 
 const classes = {
   cardContainer: {
@@ -45,7 +43,6 @@ const classes = {
 };
 
 function RestaurantCard({ restaurant, foods, setModalFoods, openModal }) {
-  const navigate = useNavigate();
   return (
     <div style={classes.cardContainer}>
       <div style={classes.retaurantInfo}>
@@ -77,14 +74,6 @@ function RestaurantCard({ restaurant, foods, setModalFoods, openModal }) {
             style={{ color: "hsl(30,90%,50%)", fontSize: "0.75rem" }}
           />
         </Button>
-        <IconButton
-          style={{ padding: 0 }}
-          onClick={() => {
-            navigate(`/restaurant?yelp_id=${restaurant.yelp_id}`);
-          }}
-        >
-          <ChevronRightIcon style={{ padding: 0 }} />
-        </IconButton>
       </div>
     </div>
   );

--- a/client/src/pages/Search/GridView/index.js
+++ b/client/src/pages/Search/GridView/index.js
@@ -9,7 +9,7 @@ const classes = {
   },
 };
 
-function CardView({ coordinates, rows }) {
+function CardView({ rows, setModalFoods, openModal }) {
   return (
     <div style={classes.restaurantList}>
       {rows.map((row) => (
@@ -17,6 +17,8 @@ function CardView({ coordinates, rows }) {
           key={row.restaurant.yelp_id}
           restaurant={row.restaurant}
           foods={row.foods}
+          setModalFoods={setModalFoods}
+          openModal={openModal}
         />
       ))}
     </div>

--- a/client/src/pages/Search/MapView/index.js
+++ b/client/src/pages/Search/MapView/index.js
@@ -2,7 +2,14 @@ import React, { useState } from "react";
 import Map from "./Map";
 import RestaurantPreview from "./RestaurantPreview";
 
-export default function MapView({ longitude, latitude, rows, updateFields }) {
+export default function MapView({
+  longitude,
+  latitude,
+  rows,
+  updateFields,
+  setModalFoods,
+  openModal,
+}) {
   const [selectedRestaurant, setSelectedRestaurant] = useState({});
   const [showing, setShowing] = useState(false);
 
@@ -28,6 +35,8 @@ export default function MapView({ longitude, latitude, rows, updateFields }) {
         <RestaurantPreview
           restaurant={selectedRestaurant}
           hideRestaurant={handleHideRestaurant}
+          setModalFoods={setModalFoods}
+          openModal={openModal}
         />
       )}
     </>

--- a/client/src/pages/Search/SearchHeader/index.js
+++ b/client/src/pages/Search/SearchHeader/index.js
@@ -1,8 +1,7 @@
 import React from "react";
 import SearchField from "./SearchField";
 import ViewToggler from "./ViewToggler";
-import { Box, Button } from "@mui/material";
-import useMenuModal from "../../../hooks/useMenuModal";
+import { Box } from "@mui/material";
 
 const classes = {
   headerContainer: {
@@ -25,11 +24,8 @@ export default function SearchHeader({
   viewMode,
   setViewMode,
 }) {
-  const { openModal, MenuModal } = useMenuModal();
   return (
     <div style={classes.headerContainer}>
-      <Button onClick={openModal}>open Modal</Button>
-      <MenuModal />
       <SearchField updateFields={updateFields} searchFields={searchFields} />
       <Box sx={classes.separator} />
       <ViewToggler viewMode={viewMode} setViewMode={setViewMode} />

--- a/client/src/pages/Search/index.js
+++ b/client/src/pages/Search/index.js
@@ -10,14 +10,13 @@ import { useJsApiLoader } from "@react-google-maps/api";
 import AddressSearch from "./AddressSearch";
 import { DEFAULT_SEARCH_QUERY, SEARCH_LOCATION_TYPES } from "./constants";
 import useMenuModal from "../../hooks/useMenuModal";
-import { Button } from "@mui/material";
 
 export default function Search() {
   const dispatch = useDispatch();
   const [restaurants, setRestaurants] = useState([]);
   const [searchFields, setSearchFields] = useState(DEFAULT_SEARCH_QUERY);
   const [viewMode, setViewMode] = useState("map");
-  const { openModal, MenuModal } = useMenuModal();
+  const { openModal, setFoods, MenuModal } = useMenuModal();
 
   const { isLoaded } = useJsApiLoader({
     id: "google-map-script",
@@ -76,7 +75,6 @@ export default function Search() {
 
   return (
     <ThemeProvider theme={theme}>
-      <Button onClick={openModal}>open Modal</Button>
       <MenuModal />
       {isLoaded && (
         <>
@@ -87,13 +85,21 @@ export default function Search() {
             setViewMode={setViewMode}
           />
           <AddressSearch updateFields={updateFields} />
-          {viewMode === "grid" && <GridView rows={restaurants} />}
+          {viewMode === "grid" && (
+            <GridView
+              rows={restaurants}
+              setModalFoods={setFoods}
+              openModal={openModal}
+            />
+          )}
           {viewMode === "map" && (
             <MapView
               latitude={searchFields.latitude}
               longitude={searchFields.longitude}
               rows={restaurants}
               updateFields={updateFields}
+              setModalFoods={setFoods}
+              openModal={openModal}
             />
           )}
         </>

--- a/client/src/pages/Search/index.js
+++ b/client/src/pages/Search/index.js
@@ -9,12 +9,15 @@ import SearchHeader from "./SearchHeader";
 import { useJsApiLoader } from "@react-google-maps/api";
 import AddressSearch from "./AddressSearch";
 import { DEFAULT_SEARCH_QUERY, SEARCH_LOCATION_TYPES } from "./constants";
+import useMenuModal from "../../hooks/useMenuModal";
+import { Button } from "@mui/material";
 
 export default function Search() {
   const dispatch = useDispatch();
   const [restaurants, setRestaurants] = useState([]);
   const [searchFields, setSearchFields] = useState(DEFAULT_SEARCH_QUERY);
   const [viewMode, setViewMode] = useState("map");
+  const { openModal, MenuModal } = useMenuModal();
 
   const { isLoaded } = useJsApiLoader({
     id: "google-map-script",
@@ -73,6 +76,8 @@ export default function Search() {
 
   return (
     <ThemeProvider theme={theme}>
+      <Button onClick={openModal}>open Modal</Button>
+      <MenuModal />
       {isLoaded && (
         <>
           <SearchHeader


### PR DESCRIPTION
Restyle restaurant card's food count to be a button
Removed the arrow redirect button, waiting for feedback on where to move the redirect functionality
When user clicks the food count button, a modal popups showing the foods from that restaurant.
Foods are rendered using @Remos96's food card component