### PR TITLE
Prevent creation of restaurants without coordinates

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "build": "tsc",
     "watch-ts": "tsc -w",
+    "start": "node dist/index.js",
     "watch-node": "nodemon dist/index.js",
     "watch": "concurrently -k -p \"[{name}]\" -n \"TypeScript,Node\" -c \"yellow.bold,cyan.bold,green.bold\" \"npm run watch-ts\" \"npm run watch-node\"",
     "test": "set NODE_ENV=test&& jest ./tests --runInBand --detectOpenHandles --forceExit"

--- a/server/src/yelp-services/api.ts
+++ b/server/src/yelp-services/api.ts
@@ -37,9 +37,12 @@ export async function fetchRestaurants(
       })
       .then((res) => res.data);
 
-    const parsedRestaurants = response.businesses.map((restaurant) =>
-      yelpRestaurantParser(restaurant)
-    );
+    const parsedRestaurants = response.businesses
+      .filter((restaurant) => {
+        const { longitude, latitude } = restaurant.coordinates;
+        return !!longitude && !!latitude;
+      })
+      .map((restaurant) => yelpRestaurantParser(restaurant));
 
     return parsedRestaurants;
   } catch (err) {


### PR DESCRIPTION
There are some restaurants in the yelp response that arrives with no coordinates.
A simple fix: just filter them out since we can't create them.