### PR TITLE
Dock preview to the bottom of the map

### DIFF
--- a/client/src/pages/Search/MapView/index.js
+++ b/client/src/pages/Search/MapView/index.js
@@ -25,7 +25,7 @@ export default function MapView({
   }
 
   return (
-    <>
+    <div style={{ position: "relative" }}>
       <Map
         longitude={longitude}
         latitude={latitude}
@@ -33,15 +33,17 @@ export default function MapView({
         updateFields={updateFields}
         showRestaurant={handleShowRestaurant}
       />
-      {!!showing && (
-        <RestaurantPreview
-          restaurant={selectedRestaurant}
-          foods={restaurantFoods}
-          hideRestaurant={handleHideRestaurant}
-          setModalFoods={setModalFoods}
-          openModal={openModal}
-        />
+      {showing && (
+        <div style={{ position: "absolute", bottom: 0, width: "100%" }}>
+          <RestaurantPreview
+            restaurant={selectedRestaurant}
+            foods={restaurantFoods}
+            hideRestaurant={handleHideRestaurant}
+            setModalFoods={setModalFoods}
+            openModal={openModal}
+          />
+        </div>
       )}
-    </>
+    </div>
   );
 }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/112503024/233525360-fdcc231d-54d5-444f-a14d-cc912ff07db3.png)
Docked restaurant preview to the bottom of the map. The built in google maps tools (zoom in, street preview) will be moved in the future. This is for mobile user accessibility, less scrolling is required to see and use the restaurant preview. 