### PR TITLE
Reposition map options

### DIFF
--- a/client/src/pages/Search/MapView/Map.js
+++ b/client/src/pages/Search/MapView/Map.js
@@ -26,12 +26,23 @@ function Map({ longitude, latitude, rows, updateFields, showRestaurant }) {
 
   const AMONGUS = require("../../../assets/images/among-us.webp");
 
+  const options = {
+    zoomControlOptions: {
+      position: google.maps.ControlPosition.RIGHT_TOP,
+    },
+    streetViewControlOptions: {
+      position: google.maps.ControlPosition.RIGHT_TOP,
+    },
+    mapTypeControl: false,
+  };
+
   return (
     <GoogleMap
       state={map}
       mapContainerStyle={containerStyle}
       center={center}
       onLoad={onLoad}
+      options={options}
       onUnmount={onUnmount}
     >
       <MarkerF


### PR DESCRIPTION
- Repositioned zoom and street view buttons to top right of map (to support restaurant preview)
- Removed map view options
![image](https://user-images.githubusercontent.com/51217000/233529815-7e152a6e-d659-4468-86f3-b8874bf838f2.png)
