### PR TITLE
Add weighted RNG for manhattan coordinates generator

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "@turf/area": "^6.5.0",
         "@turf/random": "^6.5.0",
         "axios": "^1.3.4",
         "body-parser": "^1.20.2",
@@ -1099,10 +1100,33 @@
       "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==",
       "dev": true
     },
+    "node_modules/@turf/area": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@turf/area/-/area-6.5.0.tgz",
+      "integrity": "sha512-xCZdiuojokLbQ+29qR6qoMD89hv+JAgWjLrwSEWL+3JV8IXKeNFl6XkEJz9HGkVpnXvQKJoRz4/liT+8ZZ5Jyg==",
+      "dependencies": {
+        "@turf/helpers": "^6.5.0",
+        "@turf/meta": "^6.5.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
     "node_modules/@turf/helpers": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-6.5.0.tgz",
       "integrity": "sha512-VbI1dV5bLFzohYYdgqwikdMVpe7pJ9X3E+dlr425wa2/sMJqYDhTO++ec38/pcPvPE6oD9WEEeU3Xu3gza+VPw==",
+      "funding": {
+        "url": "https://opencollective.com/turf"
+      }
+    },
+    "node_modules/@turf/meta": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-6.5.0.tgz",
+      "integrity": "sha512-RrArvtsV0vdsCBegoBtOalgdSOfkBrTJ07VkpiCnq/491W67hnMWmDu7e6Ztw0C3WldRYTXkg3SumfdzZxLBHA==",
+      "dependencies": {
+        "@turf/helpers": "^6.5.0"
+      },
       "funding": {
         "url": "https://opencollective.com/turf"
       }
@@ -6456,10 +6480,27 @@
       "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==",
       "dev": true
     },
+    "@turf/area": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@turf/area/-/area-6.5.0.tgz",
+      "integrity": "sha512-xCZdiuojokLbQ+29qR6qoMD89hv+JAgWjLrwSEWL+3JV8IXKeNFl6XkEJz9HGkVpnXvQKJoRz4/liT+8ZZ5Jyg==",
+      "requires": {
+        "@turf/helpers": "^6.5.0",
+        "@turf/meta": "^6.5.0"
+      }
+    },
     "@turf/helpers": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-6.5.0.tgz",
       "integrity": "sha512-VbI1dV5bLFzohYYdgqwikdMVpe7pJ9X3E+dlr425wa2/sMJqYDhTO++ec38/pcPvPE6oD9WEEeU3Xu3gza+VPw=="
+    },
+    "@turf/meta": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-6.5.0.tgz",
+      "integrity": "sha512-RrArvtsV0vdsCBegoBtOalgdSOfkBrTJ07VkpiCnq/491W67hnMWmDu7e6Ztw0C3WldRYTXkg3SumfdzZxLBHA==",
+      "requires": {
+        "@turf/helpers": "^6.5.0"
+      }
     },
     "@turf/random": {
       "version": "6.5.0",

--- a/server/package.json
+++ b/server/package.json
@@ -13,6 +13,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "@turf/area": "^6.5.0",
     "@turf/random": "^6.5.0",
     "axios": "^1.3.4",
     "body-parser": "^1.20.2",

--- a/server/src/yelp-services/manhattan-random.ts
+++ b/server/src/yelp-services/manhattan-random.ts
@@ -1,17 +1,51 @@
 import { CLICK_THAT_HOOD_MANHATTAN } from "./constants/manhattan-areas";
 import { randomPoint } from "@turf/random";
+import area from "@turf/area";
 
-const MANHATTAN_REGIONS = CLICK_THAT_HOOD_MANHATTAN.features.map((feature) => ({
-  name: feature.properties.name,
-  coordinates: feature.geometry.coordinates[0][0],
-}));
+type RegionInfo = {
+  name: string;
+  coordinates: number[][];
+  area: number;
+};
+
+function generatePrefixSum(regions: RegionInfo[]): number[] {
+  const result: number[] = [];
+
+  let cummulativeSum: number = 0;
+  regions.forEach((region: RegionInfo) => {
+    cummulativeSum += region.area;
+    result.push(cummulativeSum);
+  });
+
+  return result;
+}
+
+const MANHATTAN_REGIONS: RegionInfo[] = CLICK_THAT_HOOD_MANHATTAN.features
+  .map((feature, index) => ({
+    name: feature.properties.name,
+    coordinates: feature.geometry.coordinates[0][0],
+    area: area(CLICK_THAT_HOOD_MANHATTAN.features[index] as any),
+  }))
+  .sort((a: RegionInfo, b: RegionInfo) => a.area - b.area);
+
+const totalArea: number = MANHATTAN_REGIONS.reduce(
+  (total: number, curr: RegionInfo) => total + curr.area,
+  0
+);
+
+// use prefix array to determine the associated random area region
+// if randomArea @ prefixSum[i], then MANHATTAN_REGIONS[i] will be scraped
+const regionAreaPrefixSum: number[] = generatePrefixSum(MANHATTAN_REGIONS);
 
 export function generateRandomManhattanCoordinates(): {
   region: string;
   coordinates: Coordinates;
 } {
-  const randomIndex = Math.floor(Math.random() * MANHATTAN_REGIONS.length);
-  const randomRegion = MANHATTAN_REGIONS[randomIndex];
+  const randomAreaValue = Math.floor(Math.random() * totalArea);
+  const regionIndex = regionAreaPrefixSum.findIndex(
+    (area: number) => area > randomAreaValue
+  );
+  const randomRegion = MANHATTAN_REGIONS[regionIndex];
 
   const coordinates = randomPoint(1, {
     bbox: randomRegion.coordinates.flat() as any,
@@ -20,7 +54,7 @@ export function generateRandomManhattanCoordinates(): {
   const [longitude, latitude] = coordinates;
 
   return {
-    region: MANHATTAN_REGIONS[randomIndex].name,
+    region: MANHATTAN_REGIONS[regionIndex].name,
     coordinates: { longitude, latitude },
   };
 }


### PR DESCRIPTION
### Issue: No Weighted RNG for Generating Coordinates from Region
There was an issue where all regions of Manhattan had an equal chance of being selected for scraping regardless of their area.
For example, the smallest region (Liberty Island) had the same chance as the largest region (Harlem)

This PR adds a weight to the RNG by accounting for the region's area, such that larger areas have a higher chance of being scraped.
### Method:
- Calculate the area for each region
- Generate a random number between 0 and the sum of all areas (call this random area value)
- Create a prefix sum array to store the region's prefix-area upper bound like a piechart
- The region to scrape will be at index `i`, where `region[i].area` is the first region with prefix-area is greater than the random area value

### Explanation:
![image](https://user-images.githubusercontent.com/51217000/233763404-eadde041-8232-4fc5-99b9-90909f2a00ac.png)
![image](https://user-images.githubusercontent.com/51217000/233763687-8286eb86-ebab-4d88-96a1-6cbcd43828ac.png)

### Updated Measurements:
See mini-experiment on how the weights affect the odds:
![image](https://user-images.githubusercontent.com/51217000/233762656-821bcbe1-9da6-4c12-84d0-88beb227c77f.png)

