### PR TITLE
Add navbar image padding

### DIFF
--- a/client/src/components/Navbar/index.js
+++ b/client/src/components/Navbar/index.js
@@ -17,7 +17,12 @@ export default function Navbar() {
     <nav>
       <div className="navbar-wrapper">
         <div className="navbar-content">
-          <img src={logo} className="logo" alt="logo" />
+          <img
+            src={logo}
+            className="logo"
+            alt="logo"
+            style={{ paddingLeft: "0.75rem" }}
+          />
           <Link style={linkStyle} to="/search">
             Search
           </Link>
@@ -30,7 +35,12 @@ export default function Navbar() {
               target="_blank"
               rel="noreferrer"
             >
-              <img src={githubLogo} className="logo" alt="github-logo" />
+              <img
+                src={githubLogo}
+                className="logo"
+                alt="github-logo"
+                style={{ paddingRight: "0.75rem" }}
+              />
             </a>
           </div>
         </div>


### PR DESCRIPTION
Added padding around the navbar images to make it less tight.
Before:
![image](https://user-images.githubusercontent.com/112503024/234450316-c0be2fb0-4499-402b-b119-fffd5eb178ee.png)
After:
![image](https://user-images.githubusercontent.com/112503024/234450385-87b87097-063b-4250-9bb4-2983b0e11e9d.png)
