### PR TITLE
Implement pagination for restaurant response

### DIFF
--- a/server/src/constants/restaurants.ts
+++ b/server/src/constants/restaurants.ts
@@ -1,0 +1,2 @@
+// Used for pagination to limit restaurants displayed in restaurants
+export const RESTAURANT_LIMIT = 20;

--- a/server/src/controllers/restaurant.ts
+++ b/server/src/controllers/restaurant.ts
@@ -2,6 +2,7 @@ import { Request, Response } from "express";
 import RestaurantService, { RestaurantResult } from "../services/restaurant";
 import { FoodDocument, FoodItem } from "../models/Food";
 import { pick, omit } from "lodash";
+import { RESTAURANT_LIMIT } from "../constants/restaurants";
 
 // Presenter functions to remove unused fields
 function presentFoods(foods: FoodDocument[]): FoodItem[] {
@@ -27,14 +28,21 @@ async function findNearbyRestaurants(
     const latitude: number = parseFloat(request.query.latitude as string);
     const longitude: number = parseFloat(request.query.longitude as string);
     const meters: number = parseInt(request.query.meters as string);
-    const restaurants = await RestaurantService.findNear(
+    const page: number = parseFloat(request.query.page as string);
+    const skip = (!isNaN(page) ? page : 0) * RESTAURANT_LIMIT;
+
+    const foundRestaurants = await RestaurantService.findNear(
       [longitude, latitude],
-      meters
+      meters,
+      skip,
+      RESTAURANT_LIMIT
     );
 
     response.status(200).json({
-      count: restaurants.length,
-      rows: restaurants.map((restaurant) => presentRestaurant(restaurant)),
+      count: foundRestaurants.count,
+      rows: foundRestaurants.restaurants.map((restaurant) =>
+        presentRestaurant(restaurant)
+      ),
     });
   } catch (error) {
     response.status(500).json(error);
@@ -49,15 +57,22 @@ async function findNearWithinBudget(
     const longitude: number = parseFloat(request.query.longitude as string);
     const search_radius: number = parseInt(request.query.meters as string);
     const budget: number = parseFloat(request.query.budget as string);
-    const restaurants = await RestaurantService.findNearWithinBudget(
+    const page: number = parseFloat(request.query.page as string);
+    const skip = (!isNaN(page) ? page : 0) * RESTAURANT_LIMIT;
+
+    const foundRestaurants = await RestaurantService.findNearWithinBudget(
       [longitude, latitude],
       search_radius,
-      budget
+      budget,
+      skip,
+      RESTAURANT_LIMIT
     );
 
     response.status(200).json({
-      count: restaurants.length,
-      rows: restaurants.map((restaurant) => presentRestaurant(restaurant)),
+      count: foundRestaurants.count,
+      rows: foundRestaurants.restaurants.map((restaurant) =>
+        presentRestaurant(restaurant)
+      ),
     });
   } catch (error) {
     response.status(500).json(error);

--- a/server/src/services/restaurant.ts
+++ b/server/src/services/restaurant.ts
@@ -155,7 +155,6 @@ async function findNear(
   skip: number,
   limit: number
 ): Promise<NearbyRestaurantsResult> {
-  console.log({ skip, limit });
   const nearbyQuery = generateNearbyQuery(coordinates, searchRadius);
   const limitRestaurants = generateRestaurantLimitQuery(skip, limit);
 

--- a/server/tests/services/restaurants/tests/retrieve-nearby-budget.ts
+++ b/server/tests/services/restaurants/tests/retrieve-nearby-budget.ts
@@ -41,24 +41,26 @@ export async function testRetrieveNearbyRestaurantsInBudget() {
   const nearbyInBudget = await RestaurantService.findNearWithinBudget(
     [-74.00565, 40.74207],
     5000,
-    budget
+    budget,
+    0,
+    10
   );
 
-  const nearbyRestaurantNames = nearbyInBudget.map(
+  const nearbyRestaurantNames = nearbyInBudget.restaurants.map(
     (result) => result.restaurant.name
   );
 
-  const retrievedPrices = nearbyInBudget
+  const retrievedPrices = nearbyInBudget.restaurants
     .map((match) => match.foods.map((food) => food.price))
     .flat();
 
-  const createdFoods = Array(nearbyInBudget.length).fill(manyTestFoods).flat();
+  const createdFoods = Array(nearbyInBudget.count).fill(manyTestFoods).flat();
 
   const expectedPrices = createdFoods
     .flatMap((food) => food.price)
     .filter((price) => price <= budget);
 
-  expect(nearbyInBudget.length).toBe(3);
+  expect(nearbyInBudget.count).toBe(3);
   expect(nearbyRestaurantNames).toEqual([
     "Very Fresh Noodles",
     "Omusubi Gonbei",

--- a/server/tests/services/restaurants/tests/retrieve-nearby.ts
+++ b/server/tests/services/restaurants/tests/retrieve-nearby.ts
@@ -22,14 +22,16 @@ export async function testRetrieveNearbyRestaurants() {
 
   const nearbyRestaurants = await RestaurantService.findNear(
     [-74.00565, 40.74207],
-    5000
+    5000,
+    0,
+    3
   );
 
-  const nearbyRestaurantNames = nearbyRestaurants?.map(
+  const nearbyRestaurantNames = nearbyRestaurants.restaurants?.map(
     (result) => result.restaurant.name
   );
 
-  expect(nearbyRestaurants.length).toBe(3);
+  expect(nearbyRestaurants.count).toBe(3);
   expect(nearbyRestaurantNames).toEqual([
     "Very Fresh Noodles",
     "Omusubi Gonbei",


### PR DESCRIPTION
Implemented pagination for nearby restaurant querying
Changes to searching:
- Limits to 20 restaurants per response
- Takes an optional `page` query key from http request. This is how many documents to skip before limit

We'll need to add paging to the front end, as well as implement custom sorts