### PR TITLE
Add price category pagination filter

### DIFF
--- a/server/src/controllers/restaurant.ts
+++ b/server/src/controllers/restaurant.ts
@@ -19,6 +19,20 @@ function presentRestaurant(result: RestaurantResult) {
   };
 }
 
+function generateFiltersFromQuery(query: any): RestaurantFilter {
+  const priceCategories = query.price_categories as PriceCategory[];
+  const foodCategories = query.food_categories as FoodCategory[];
+  const transactions = query.transactions as TransactionCategory[];
+
+  const restaurantFilter: RestaurantFilter = {
+    price_categories: priceCategories,
+    food_categories: foodCategories,
+    transactions: transactions,
+  };
+
+  return restaurantFilter;
+}
+
 // Controllers
 async function findNearbyRestaurants(
   request: Request,
@@ -31,11 +45,14 @@ async function findNearbyRestaurants(
     const page: number = parseFloat(request.query.page as string);
     const skip = (!isNaN(page) ? page : 0) * RESTAURANT_LIMIT;
 
+    const restaurantFilter = generateFiltersFromQuery(request.query);
+
     const foundRestaurants = await RestaurantService.findNear(
       [longitude, latitude],
       meters,
       skip,
-      RESTAURANT_LIMIT
+      RESTAURANT_LIMIT,
+      restaurantFilter
     );
 
     response.status(200).json({
@@ -60,12 +77,15 @@ async function findNearWithinBudget(
     const page: number = parseFloat(request.query.page as string);
     const skip = (!isNaN(page) ? page : 0) * RESTAURANT_LIMIT;
 
+    const restaurantFilter = generateFiltersFromQuery(request.query);
+
     const foundRestaurants = await RestaurantService.findNearWithinBudget(
       [longitude, latitude],
       search_radius,
       budget,
       skip,
-      RESTAURANT_LIMIT
+      RESTAURANT_LIMIT,
+      restaurantFilter
     );
 
     response.status(200).json({
@@ -97,7 +117,8 @@ async function findFoodCategories(
   response: Response
 ): Promise<void> {
   try {
-    const foodCategories: string[] = await RestaurantService.findFoodCategories();
+    const foodCategories: string[] =
+      await RestaurantService.findFoodCategories();
     response.status(200).json(foodCategories);
   } catch (error) {
     response.status(500).json(error);

--- a/server/src/types/filters.d.ts
+++ b/server/src/types/filters.d.ts
@@ -1,0 +1,16 @@
+declare enum FILTERS {
+  FOOD_CATEGORY = "food_category",
+  PRICE_CATEGORY = "price_category",
+  TRANSACTIONS = "transactions",
+}
+
+type PriceCategory = "$" | "$$" | "$$$" | "$$$$";
+type FoodCategory = string;
+type TransactionCategory = "delivery" | "pickup" | "restaurant_reservation";
+
+type RestaurantFilterOptions = {
+  price_categories: PriceCategory[];
+  food_categories: string[];
+  transactions: TransactionCategory[];
+};
+type RestaurantFilter = Partial<RestaurantFilterOptions>;


### PR DESCRIPTION
Add price category filter for pagination

Changes to the nearby-budget query:
Originally, we had a query that did the following in sequential order:
1. find restaurants near user
2. populate foods
3. filter for restaurants in budget

With these changes, I partitioned it better.
1. nearbyQuery: find restaurants near user
+++ priceFilterQuery: find restaurants matching price category
2. populateFoods: ...

Just inserted price filter query right after the nearby query pipeline.
note that geoNear must be the first query
![image](https://user-images.githubusercontent.com/51217000/235282444-92af804a-a065-463f-93aa-62a362660b9b.png)

Changes to nearby-in-budget route: now accepts an array of price categories to filter by
if `['$', '$$']` provided, then database filters for restaurants that have either `'$'` or `'$$'` as the price category

![image](https://user-images.githubusercontent.com/51217000/235281433-2723f339-46ae-4660-95d8-d75593b371bd.png)
