### PR TITLE
Fix pagination display for no matches

### DIFF
--- a/server/src/services/restaurant.ts
+++ b/server/src/services/restaurant.ts
@@ -136,16 +136,15 @@ function generateRestaurantLimitQuery(
     {
       $facet: {
         restaurants: [{ $skip: skippedDocuments }, { $limit: documentLimit }],
-        count: [{ $group: { _id: null, count: { $sum: 1 } } }],
+        count: [{ $count: "count" }],
       },
-    },
-    {
-      $unwind: "$count",
     },
     {
       $project: {
         restaurants: true,
-        count: "$count.count",
+        count: {
+          $ifNull: [{ $first: "$count.count" }, 0],
+        },
       },
     },
   ];


### PR DESCRIPTION
There was a bug where if an area with no restaurants was searched, the aggregation pipeline would return an empty array.
It's intended for the aggregation pipeline to return an array of one document, and that one document has this format:
```js
{
   restaurants: Restaurant+Foods[],
   count: number
}
```
I previously used anquery from an SO post that only worked for non-empty responses.

This PR fixes it so that if there are no documents, it will still return with an array containing a single document.
Using the `ifNull` aggregation, we can fallback to 0 if there are no documents
And that single document will be the response representing 0 matches.
```js
{
   restaurants: [],
   count: 0
}
```

https://stackoverflow.com/a/74126104/17920552
https://www.mongodb.com/docs/manual/reference/operator/aggregation/ifNull/