### PR TITLE
Implement restaurant sort by food count

### DIFF
--- a/server/src/constants/sortables.ts
+++ b/server/src/constants/sortables.ts
@@ -1,0 +1,26 @@
+export enum SORT_KEY {
+  FOODS = "foods",
+  REVIEWS = "reviews",
+  RATING = "rating",
+  LAST_UPDATED = "last_updated",
+}
+
+export type SortKey =
+  | SORT_KEY.FOODS
+  | SORT_KEY.REVIEWS
+  | SORT_KEY.RATING
+  | SORT_KEY.LAST_UPDATED;
+
+export enum SORT_DIRECTION {
+  ASCENDING = "asc",
+  DESCENDING = "desc",
+}
+
+export type SortDirection =
+  | SORT_DIRECTION.ASCENDING
+  | SORT_DIRECTION.DESCENDING;
+
+export const SORT_DIRECTION_MAPPING = {
+  [SORT_DIRECTION.ASCENDING]: 1,
+  [SORT_DIRECTION.DESCENDING]: -1,
+};

--- a/server/src/controllers/restaurant.ts
+++ b/server/src/controllers/restaurant.ts
@@ -3,6 +3,7 @@ import RestaurantService, { RestaurantResult } from "../services/restaurant";
 import { FoodDocument, FoodItem } from "../models/Food";
 import { pick, omit } from "lodash";
 import { RESTAURANT_LIMIT } from "../constants/restaurants";
+import { SortKey, SortDirection } from "../constants/sortables";
 
 // Presenter functions to remove unused fields
 function presentFoods(foods: FoodDocument[]): FoodItem[] {
@@ -44,6 +45,8 @@ async function findNearbyRestaurants(
     const meters: number = parseInt(request.query.meters as string);
     const page: number = parseFloat(request.query.page as string);
     const skip = (!isNaN(page) ? page : 0) * RESTAURANT_LIMIT;
+    const sortBy = request.query.sort_by as SortKey;
+    const sortDirection = request.query.sort_dir as SortDirection;
 
     const restaurantFilter = generateFiltersFromQuery(request.query);
 
@@ -52,7 +55,9 @@ async function findNearbyRestaurants(
       meters,
       skip,
       RESTAURANT_LIMIT,
-      restaurantFilter
+      restaurantFilter,
+      sortBy,
+      sortDirection
     );
 
     response.status(200).json({
@@ -76,6 +81,8 @@ async function findNearWithinBudget(
     const budget: number = parseFloat(request.query.budget as string);
     const page: number = parseFloat(request.query.page as string);
     const skip = (!isNaN(page) ? page : 0) * RESTAURANT_LIMIT;
+    const sortBy = request.query.sort_by as SortKey;
+    const sortDirection = request.query.sort_dir as SortDirection;
 
     const restaurantFilter = generateFiltersFromQuery(request.query);
 
@@ -85,7 +92,9 @@ async function findNearWithinBudget(
       budget,
       skip,
       RESTAURANT_LIMIT,
-      restaurantFilter
+      restaurantFilter,
+      sortBy,
+      sortDirection
     );
 
     response.status(200).json({


### PR DESCRIPTION
Allow for api to query restaurants by amount of foods available

Method: Add a food_count field using `$size` operator, and sort by that field

Changes to route: now accepts a `sort_by` and `sort_dir` in the url.

Note that any sortable feature will cause the query to take longer. Nothing we can do about that

examples below: not integrated with front-end yet.

using `sort_by=foods` and `sort_dir=desc`
![image](https://user-images.githubusercontent.com/51217000/235568550-40f8718e-0c35-48a9-9082-9b424649ffc1.png)

`sort_dir=asc`
![image](https://user-images.githubusercontent.com/51217000/235568644-81f027d2-21fe-4049-91e2-8682260b023f.png)


