### PR TITLE
Integrate sort query to search page

### DIFF
--- a/client/src/pages/Search/SearchHeader/PageNavigation.js
+++ b/client/src/pages/Search/SearchHeader/PageNavigation.js
@@ -35,7 +35,7 @@ export default function PageNavigation({
         <ChevronLeftIcon />
       </IconButton>
       <div>
-        Found {lowerBound}-{upperBound} of {total_count}
+        Showing {lowerBound}-{upperBound} of {total_count}
       </div>
       <IconButton
         sx={classes.pageArrow}

--- a/client/src/pages/Search/SearchHeader/SortQuery.js
+++ b/client/src/pages/Search/SearchHeader/SortQuery.js
@@ -1,0 +1,50 @@
+import { FormControl, InputLabel, MenuItem, Select } from "@mui/material";
+import React from "react";
+
+const sortKeys = [
+  { label: "Distance", value: "distance" },
+  { label: "Average Price", value: "avg_price" },
+  { label: "Menu Items", value: "foods" },
+  { label: "Reviews", value: "reviews" },
+  { label: "Rating", value: "rating" },
+];
+
+const sortDirections = [
+  { label: "Ascending", value: "asc" },
+  { label: "Descending", value: "desc" },
+];
+
+export default function SortQuery({ updateFields, searchFields }) {
+  return (
+    <div style={{ display: "flex", gap: "1rem" }}>
+      <FormControl variant="standard" sx={{ minWidth: 120, padding: 0 }}>
+        <InputLabel>Sort By</InputLabel>
+        <Select value={searchFields.sort_by} label="Sort By">
+          {sortKeys.map((sortKey) => (
+            <MenuItem
+              key={sortKey.value}
+              value={sortKey.value}
+              onClick={() => updateFields({ sort_by: sortKey.value })}
+            >
+              {sortKey.label}
+            </MenuItem>
+          ))}
+        </Select>
+      </FormControl>
+      <FormControl variant="standard" sx={{ minWidth: 120, padding: 0 }}>
+        <InputLabel>Sort Direction</InputLabel>
+        <Select value={searchFields.sort_dir} label="Sort Direction">
+          {sortDirections.map((sortDirection) => (
+            <MenuItem
+              key={sortDirection.value}
+              value={sortDirection.value}
+              onClick={() => updateFields({ sort_dir: sortDirection.value })}
+            >
+              {sortDirection.label}
+            </MenuItem>
+          ))}
+        </Select>
+      </FormControl>
+    </div>
+  );
+}

--- a/client/src/pages/Search/SearchHeader/index.js
+++ b/client/src/pages/Search/SearchHeader/index.js
@@ -3,6 +3,7 @@ import SearchField from "./SearchField";
 import ViewToggler from "./ViewToggler";
 import { Box } from "@mui/material";
 import PageNavigation from "./PageNavigation";
+import SortQuery from "./SortQuery";
 
 const classes = {
   headerContainer: {
@@ -29,7 +30,8 @@ export default function SearchHeader({
 }) {
   return (
     <div style={classes.headerContainer}>
-      <SearchField updateFields={updateFields} searchFields={searchFields} />
+      <SearchField searchFields={searchFields} updateFields={updateFields} />
+      <SortQuery searchFields={searchFields} updateFields={updateFields} />
       <Box sx={classes.separator} />
       <ViewToggler viewMode={viewMode} setViewMode={setViewMode} />
       <PageNavigation {...pageNavigationProps} />

--- a/client/src/pages/Search/constants.js
+++ b/client/src/pages/Search/constants.js
@@ -10,6 +10,8 @@ export const DEFAULT_SEARCH_QUERY = {
   ...HUNTER_COLLEGE_COORDINATES,
   meters: 300,
   budget: 10,
+  sort_by: "direction",
+  sort_dir: "asc",
 };
 
 export const SEARCH_LOCATION_TYPES = ["places"];

--- a/client/src/pages/Search/index.js
+++ b/client/src/pages/Search/index.js
@@ -77,7 +77,8 @@ export default function Search() {
     },
   });
 
-  const { longitude, latitude, meters, budget } = searchFields;
+  const { longitude, latitude, meters, budget, sort_by, sort_dir } =
+    searchFields;
   const pageNavigationProps = {
     total_count: count,
     page_number: page,
@@ -98,7 +99,7 @@ export default function Search() {
       abortController.abort();
     };
     // eslint-disable-next-line
-  }, [longitude, latitude, meters, budget]);
+  }, [longitude, latitude, meters, budget, sort_by, sort_dir]);
 
   // Search on page change
   useEffect(() => {

--- a/server/src/services/restaurant.ts
+++ b/server/src/services/restaurant.ts
@@ -237,7 +237,11 @@ function generateSortQuery(
   // Sort by distance
   if (sortBy === SORT_KEY.DISTANCE) {
     // query defaulted to sort by distance
-    return [];
+    const sortByDistance = {
+      $sort: { "restaurant.distance": sortDirectionValue },
+    };
+    
+    return [sortByDistance];
   }
   // Sort by average price
   if (sortBy === SORT_KEY.AVERAGE_PRICE) {


### PR DESCRIPTION
Added a component in search headers for handling sort keys and sort direction
Desktop:
![image](https://user-images.githubusercontent.com/51217000/235783297-3c9b0255-2d9b-4ea0-b761-0cd49295c3c3.png)

Mobile:
![image](https://user-images.githubusercontent.com/51217000/235783689-60e80e4d-6e66-4e72-8438-c04aa9a29697.png)

