### PR TITLE
Move all map items into their own files

### DIFF
--- a/client/src/pages/Search/MapView/MapItems/FocusedMarker.js
+++ b/client/src/pages/Search/MapView/MapItems/FocusedMarker.js
@@ -1,9 +1,8 @@
 /*global google*/
-import React from "react";
 import { MarkerF } from "@react-google-maps/api";
-const AmongusVent = require("../../../assets/images/among-us-vent.png");
+const AmongusVent = require("../../../../assets/images/among-us-vent.png");
 
-export default function FocusedMarker({ selectedRestaurant, updateFields }) {
+export default function FocusedMarker({ selectedRestaurant }) {
   if (!selectedRestaurant) return <></>;
 
   const { restaurant } = selectedRestaurant;

--- a/client/src/pages/Search/MapView/MapItems/MapAvatar.js
+++ b/client/src/pages/Search/MapView/MapItems/MapAvatar.js
@@ -1,0 +1,31 @@
+/*global google*/
+import { MarkerF } from "@react-google-maps/api";
+const AMONGUS = require("../../../../assets/images/among-us.webp");
+
+// The draggable avatar for users to teleport on the map
+export default function Avatar({
+  longitude,
+  latitude,
+  updateFields,
+  setMapCenter,
+}) {
+  return (
+    <MarkerF
+      position={{ lng: longitude, lat: latitude }}
+      icon={{
+        url: AMONGUS,
+        scaledSize: new google.maps.Size(40, 48),
+      }}
+      draggable
+      onDragEnd={(event) => {
+        const updatedLatitude = event.latLng.lat();
+        const updatedLongitude = event.latLng.lng();
+        updateFields({
+          longitude: updatedLongitude,
+          latitude: updatedLatitude,
+        });
+        setMapCenter({ lat: updatedLatitude, lng: updatedLongitude });
+      }}
+    />
+  );
+}

--- a/client/src/pages/Search/MapView/MapItems/MapCircle.js
+++ b/client/src/pages/Search/MapView/MapItems/MapCircle.js
@@ -1,0 +1,12 @@
+import { CircleF } from "@react-google-maps/api";
+
+export default function MapCircle({ longitude, latitude, searchRadius }) {
+  const circleOptions = {
+    radius: searchRadius,
+    fillColor: "hsla(25,80%,60%,60%)",
+    strokeColor: "hsla(25,80%,60%,90%)",
+    center: { lng: longitude, lat: latitude },
+  };
+
+  return <CircleF options={circleOptions} />
+}

--- a/client/src/pages/Search/MapView/MapItems/RestaurantMarkers.js
+++ b/client/src/pages/Search/MapView/MapItems/RestaurantMarkers.js
@@ -1,0 +1,43 @@
+import React from "react";
+import { MarkerF } from "@react-google-maps/api";
+import FocusedMarker from "./FocusedMarker";
+
+export default function RestaurantMarkers({
+  rows,
+  showRestaurant,
+  setMapCenter,
+}) {
+  const [selectedRestaurantId, setSelectedRestaurantId] = React.useState(null);
+  const nonSelectedRestaurants = rows.filter(
+    (row) => row.restaurant.yelp_id !== selectedRestaurantId
+  );
+  const selectedRestaurant = rows.find(
+    (row) => row.restaurant.yelp_id === selectedRestaurantId
+  );
+
+  return (
+    <>
+      <FocusedMarker selectedRestaurant={selectedRestaurant} />
+      {nonSelectedRestaurants.map((row) => {
+        const { restaurant } = row;
+        const coordinates = restaurant.location.coordinates;
+        const [longitude, latitude] = coordinates;
+        const restaurantPosition = {
+          lng: longitude,
+          lat: latitude,
+        };
+        return (
+          <MarkerF
+            key={restaurant.yelp_id}
+            position={restaurantPosition}
+            onClick={() => {
+              showRestaurant(row);
+              setSelectedRestaurantId(restaurant.yelp_id);
+              setMapCenter(restaurantPosition);
+            }}
+          />
+        );
+      })}
+    </>
+  );
+}


### PR DESCRIPTION
Came across the map file, and it looked kinda fat
Also, there's a bug where the entire map rerenders when we click on a restaurant marker because the selectedRestauarantId state is in the map component. It should've been in whichever component where we render a list of restaurants.
because of this bug, the map recenters to the avatar because the map component rerenders.

To fix this, we just move the selected restaurant state to a RestaurantMarkers component, with it's job to render all restaurants as well as the selected restaurant. The map (parent) doesn't need to know what the markers (children) have as the selected marker

Because of this requirement, we might as well move all of our existing components into their own files because that just seems to make more sense.

Map (parent) doesn't really care that our Avatar is using amongus png, and also doesn't care which restaurant is selected

TLDR: found bug, fix requires a lil refactor, refactor looks like cleaner architecture 

Before:

https://user-images.githubusercontent.com/51217000/236118374-a10ccba7-ac68-447c-b9f8-8bca357457f3.mp4

After:

https://user-images.githubusercontent.com/51217000/236118530-3be9c8aa-6487-468f-9741-dbab3750f814.mp4

