### PR TITLE
Hide Phone Icon for Restaurants witout phone number

### DIFF
--- a/client/src/pages/Restaurant/RestaurantView/RestaurantInfo.js
+++ b/client/src/pages/Restaurant/RestaurantView/RestaurantInfo.js
@@ -53,7 +53,7 @@ export default function RestaurantInfo({ restaurant }) {
             {address1} {city}, {state} {zip_code}
           </div>
           <div style={classes.phoneContainer}>
-            <PhoneIcon style={{ color: "#13a10b" }} />
+            {phoneNumber ? <PhoneIcon style={{ color: "#13a10b" }} /> : <></>}
             <a style={{ color: "#13a10b" }} href={`tel: ${phoneNumber}`}>
               {phoneNumber}
             </a>


### PR DESCRIPTION
Removed Phone Icon For Restaurants without Phone Numbers
<img width="424" alt="Screen Shot 2023-05-06 at 2 33 55 PM" src="https://user-images.githubusercontent.com/73366731/236641148-b2743ad8-962b-460b-9395-ee9450062ecb.png">
