### PR TITLE
Add food category on enter

### DIFF
--- a/client/src/components/Filters/FoodCategoryFilter.js
+++ b/client/src/components/Filters/FoodCategoryFilter.js
@@ -25,7 +25,6 @@ export default function FoodCategoryFilter({
       limitTags={4}
       filterOptions={filterOptions}
       options={options}
-      getOptionDisabled={(option) => option}
       getOptionLabel={(option) => option}
       renderOption={(props, option) => (
         <Box component="li" {...props}>
@@ -39,11 +38,7 @@ export default function FoodCategoryFilter({
         setFoodCategories(selectedCategories ?? []);
       }}
       renderInput={(params) => (
-        <TextField
-          {...params}
-          variant="standard"
-          label="Food Categories"
-        />
+        <TextField {...params} variant="standard" label="Food Categories" />
       )}
     />
   );


### PR DESCRIPTION
It wasn't possible for users to quick select a category by hitting Enter.
That's bc I forgot to remove the `getOptionDisabled` prop, which caused all options to be disabled (but still clickable for some reason)