### PR TITLE
Move google api loader to root

### DIFF
--- a/client/src/App.js
+++ b/client/src/App.js
@@ -4,19 +4,29 @@ import Search from "./pages/Search";
 import { Route, Routes } from "react-router-dom";
 import Restaurant from "./pages/Restaurant";
 import SnackbarAlert from "./components/SnackbarAlert";
+import { useJsApiLoader } from "@react-google-maps/api";
+import { SEARCH_LOCATION_TYPES } from "./pages/Search/constants";
 
 function App() {
+  const { isLoaded } = useJsApiLoader({
+    id: "google-map-script",
+    googleMapsApiKey: process.env.REACT_APP_GOOGLE_API_KEY,
+    libraries: SEARCH_LOCATION_TYPES,
+  });
+
   return (
     <>
       <SnackbarAlert />
       <Navbar />
       <div className="page-container">
-        <Routes>
-          <Route path="/search" element={<Search />} />
-          <Route path="/restaurant" element={<Restaurant />} />
-          <Route path="/profile" element={<Profile />} />
-          <Route path="/" element={<Search />} />
-        </Routes>
+        {isLoaded && (
+          <Routes>
+            <Route path="/search" element={<Search />} />
+            <Route path="/restaurant" element={<Restaurant />} />
+            <Route path="/profile" element={<Profile />} />
+            <Route path="/" element={<Search />} />
+          </Routes>
+        )}
       </div>
     </>
   );

--- a/client/src/pages/Search/index.js
+++ b/client/src/pages/Search/index.js
@@ -5,12 +5,7 @@ import RestaurantAPI from "../../api/restaurant-api";
 import GridView from "./GridView";
 import MapView from "./MapView";
 import SearchHeader from "./SearchHeader";
-import { useJsApiLoader } from "@react-google-maps/api";
-import {
-  DEFAULT_PRICE_FILTER,
-  DEFAULT_SEARCH_QUERY,
-  SEARCH_LOCATION_TYPES,
-} from "./constants";
+import { DEFAULT_PRICE_FILTER, DEFAULT_SEARCH_QUERY } from "./constants";
 import useMenuModal from "../../hooks/useMenuModal";
 import {
   setFoodCategory,
@@ -41,12 +36,6 @@ export default function Search() {
     localStorage.getItem("view-mode") ?? "map"
   );
   const { openModal, setFoods, MenuModal } = useMenuModal();
-
-  const { isLoaded } = useJsApiLoader({
-    id: "google-map-script",
-    googleMapsApiKey: process.env.REACT_APP_GOOGLE_API_KEY,
-    libraries: SEARCH_LOCATION_TYPES,
-  });
 
   function updateFields(updatedFields) {
     setSearchFields((previousFields) => ({
@@ -169,38 +158,34 @@ export default function Search() {
   return (
     <>
       <MenuModal />
-      {isLoaded && (
-        <>
-          <SearchHeader
-            updateFields={updateFields}
-            searchFields={searchFields}
-            priceFilter={priceFilter}
-            setPriceFilter={setPriceFilter}
-            foodCategories={foodCategories}
-            setFoodCategories={setFoodCategories}
-            viewMode={viewMode}
-            setViewMode={setViewMode}
-            pageNavigationProps={pageNavigationProps}
-          />
-          {viewMode === "grid" && (
-            <GridView
-              rows={restaurants}
-              setModalFoods={setFoods}
-              openModal={openModal}
-            />
-          )}
-          {viewMode === "map" && (
-            <MapView
-              latitude={searchFields.latitude}
-              longitude={searchFields.longitude}
-              searchRadius={searchFields.meters}
-              rows={restaurants}
-              updateFields={updateFields}
-              setModalFoods={setFoods}
-              openModal={openModal}
-            />
-          )}
-        </>
+      <SearchHeader
+        updateFields={updateFields}
+        searchFields={searchFields}
+        priceFilter={priceFilter}
+        setPriceFilter={setPriceFilter}
+        foodCategories={foodCategories}
+        setFoodCategories={setFoodCategories}
+        viewMode={viewMode}
+        setViewMode={setViewMode}
+        pageNavigationProps={pageNavigationProps}
+      />
+      {viewMode === "grid" && (
+        <GridView
+          rows={restaurants}
+          setModalFoods={setFoods}
+          openModal={openModal}
+        />
+      )}
+      {viewMode === "map" && (
+        <MapView
+          latitude={searchFields.latitude}
+          longitude={searchFields.longitude}
+          searchRadius={searchFields.meters}
+          rows={restaurants}
+          updateFields={updateFields}
+          setModalFoods={setFoods}
+          openModal={openModal}
+        />
       )}
     </>
   );


### PR DESCRIPTION
Since the useJsApiLoader() was only in Search, it becomes impossible for other pages to utilize maps.
Simply moving this into App.js (the root) does the trick. Now any route can use google maps api